### PR TITLE
POSIX compatibility and fixes

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -40,7 +40,7 @@ selection_cut(struct dir_display *dir_display)
 int
 selection_del(struct dir_display *dir_display)
 {
-	char phrase_final[38] = "Procced with deletion of files? (y/n)";
+	char phrase_final[] = "Proceed with deletion of files? (y/n)";
 	move(config.size.y - 1, 0); // move to begining of line
 	clrtoeol();	  // Clean displayed path
 
@@ -54,12 +54,7 @@ selection_del(struct dir_display *dir_display)
 
 	selection_copy(dir_display);
 	for(size_t i = 0; i < file_selection.size; ++i)
-	{
-		if(fork() == 0)
-			execlp("rm", "rm", "-rf",
-			       file_selection.files[i],
-			       (char *)NULL);
-	}
+	    remove(file_selection.files[i]);
 
 	return 0;
 }

--- a/src/dir.c
+++ b/src/dir.c
@@ -1,4 +1,3 @@
-#include <sys/types.h>
 #include <sys/stat.h>
 #include <ncurses.h>
 #include <dirent.h>
@@ -7,6 +6,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <limits.h>
 
 #include "dir.h"
 

--- a/src/dir.c
+++ b/src/dir.c
@@ -47,7 +47,8 @@ list_files(struct dir_display *dir_display, char *path)
 		d = opendir(path);
 	}
 
-	for(struct dirent *dir = readdir(d); dir != NULL; dir = readdir(d))
+	for(struct dirent *dir = readdir(d); dir != NULL &&
+        i < (sizeof(tmp_list) / sizeof(char *)); dir = readdir(d))
 	{
 		// Don't Show hidden files
 		if(config.hidden || *dir->d_name != '.')


### PR DESCRIPTION
In dir.c the **PATH_MAX** macro is used but included with **sys/types.h**, I changed it to **limits.h** for better portability.
Works perfectly on OSX now (also tested on linux Manjaro).