### PR TITLE
fixed buffer overflow issue in display.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /build
 /PKG
 **/TAGS
+*.swp
+tags

--- a/src/display.c
+++ b/src/display.c
@@ -97,7 +97,7 @@ display_files(display_t dir_display, int factor)
 
 		int display_attr = 0;
 
-		char buf[1024];
+		char buf[1536];
 		sprintf(buf, "%s/%s/%s", config.path,
 			dir_display.files.dir,
 			dir_display.files.list[i]);


### PR DESCRIPTION
Buffer for sprintf was not long enough to hold minimum size for string ( without null terminator ).